### PR TITLE
./runVmTest.native takes a test case name as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ One way is to run the VM Test.
 $ sh compile.sh
 $ ./runVmTest.native
 ```
+(When `./runVmTest.native` takes an argument, it executes only the test cases whose names contain the argument as a substring.)
+
 
 Another way is to run the VM Test and measure the coverage.
 ```

--- a/tester/runVmTest.ml
+++ b/tester/runVmTest.ml
@@ -183,7 +183,7 @@ let test_one_file (path : string) ((num_success : int ref), (num_failure : int r
   let vm_arithmetic_test : json = Yojson.Basic.from_file path in
   let vm_arithmetic_test_assoc : (string * json) list = Util.to_assoc vm_arithmetic_test in
   let () =  List.iter
-     (fun (label, j) ->
+    (fun (label, j) ->
       let hit =
         match case_name with
         | Some search ->


### PR DESCRIPTION
Fixes #146