### PR TITLE
Check a big_int before converting it to int

### DIFF
--- a/lem/evm.lem
+++ b/lem/evm.lem
@@ -1418,10 +1418,12 @@ end
 
 (* A utility function for storing a list of bytes in the memory: *)
 val store_byte_list_memory : w256 -> list byte -> memory -> memory
-let store_byte_list_memory pos lst orig p = match index lst (natFromNatural (word256ToNatural (p-pos))) with
- | Just e -> e
- | Nothing -> orig p
-end
+let store_byte_list_memory pos lst orig p =
+  if word256UGE (p - pos) (word256FromNat (length lst)) then orig p else
+   match index lst (natFromNatural (word256ToNatural (p-pos))) with
+   | Just e -> e
+   | Nothing -> orig p
+   end
 
 (* Using the function above, it is straightforward to store a byte in the memory. *)
 val store_word_memory : w256 -> w256 -> memory -> memory


### PR DESCRIPTION
Before this commit, `./runVmTest.native` failed with an error message about
`int_of_big_int`

After this commit, the error disappears