### PR TITLE
When CREATE reaches the global stack limit, the nonce is not updated

### DIFF
--- a/lem/block.lem
+++ b/lem/block.lem
@@ -423,10 +423,10 @@ let next = function
          Continue (<| global with g_stack=((state,v,c,get_hint stuff)::global.g_stack);
                                  g_current=n_state; g_cctx=cctx; g_vmstate=InstructionContinue nv |>)
       | ContractCreate args ->
-         let state = update_nonce state c.cctx_this in
          if length global.g_stack > 1023 then
             let nv = <| v with vctx_stack = 0 :: v.vctx_stack |> in
             Continue (<| global with g_current = state; g_vmstate = InstructionContinue nv |>) else
+         let state = update_nonce state c.cctx_this in
          let n_state = update_return state c.cctx_this v in
          let n_state = update_tr n_state c.cctx_this args.createarg_value in
          let n_acc = n_state c.cctx_this in


### PR DESCRIPTION
Fix #393