### PR TITLE
Fix check in Cgascap to account for memu_extra.

### DIFF
--- a/lem/evm.lem
+++ b/lem/evm.lem
@@ -1337,7 +1337,7 @@ let L x = x - x / 64
    a boolean indicating emptiness of the recipient, and the remaining gas of the caller *)
 val Cgascap : w256 -> w256 -> bool -> integer -> network -> integer -> integer
 let Cgascap mu0 mu2 emp remaining_gas net memu_extra =
-  if remaining_gas >= Cextra mu2 emp net then
+  if remaining_gas >= Cextra mu2 emp net + memu_extra then
     integerMin (L (remaining_gas - Cextra mu2 emp net - memu_extra)) (uint mu0)
   else
     uint mu0


### PR DESCRIPTION
Commit 97357e06b174b220eb62112f474a862498fcf002
added the memu_extra argument to Cgascap but did
not update the condition sanity check.
I believe this is a typo as Cgascap should never
return a negative value.

Also, I'm not sure how many of the changes in the commit
mentioned above match the content of the Yellow paper.